### PR TITLE
Add barcode flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 #     go build -o totp-arm64 && CGO_ENABLED=1 GOARCH=amd64 go build -o totp-amd64
 /totp-amd64
 /totp-arm64
+
+# GoLand
+.idea


### PR DESCRIPTION
QRCode image with padding causes FormatException.
Fix FormatException using PURE_BARCODE hint. 
[ref](https://stackoverflow.com/questions/46896962/zxing-formatexception-decoding-zxing-generated-qrcode)

<img width="516" alt="image" src="https://user-images.githubusercontent.com/28289693/192974045-05b01344-cf91-4573-98ad-ca3f5f0cf3b1.png">
